### PR TITLE
Add function to set / unset credentials for Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,19 @@ declare const header: (name: string, value: string) => (request: Request) => Req
 Sets one of the [request headers][] of a request to the given value. Uses
 [`Headers.set`](#headersset) so be aware of its gotchas.
 
+#### `Req.credentials`
+
+```ts
+declare const credentials: (credentials: RequestCredentials) => (request: Request) => Request
+```
+
+Set the [credentials mode][] of a request to the given value.
+
+> [!CAUTION]
+>
+> This function throws when the `credentials` parameter is not a valid
+> RequestCredentials value.
+
 #### `Req.append`
 
 ```ts
@@ -973,6 +986,7 @@ default handler for unexpected cases in, for example,
 [request method]: https://developer.mozilla.org/docs/Web/API/Request/method
 [request headers]: https://developer.mozilla.org/docs/Web/API/Request/headers
 [redirect mode]: https://developer.mozilla.org/docs/Web/API/Request/redirect
+[credentials mode]: https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
 
 [Response]: https://developer.mozilla.org/docs/Web/API/Response
 [`Response#text()`]: https://developer.mozilla.org/docs/Web/API/Response/text

--- a/src/Fetch.ts
+++ b/src/Fetch.ts
@@ -1,4 +1,4 @@
-import {pipe, constant, identity} from 'fp-ts/lib/function.js'
+import {pipe, constant, identity, flow} from 'fp-ts/lib/function.js'
 import * as TE from 'fp-ts/lib/TaskEither.js';
 import * as E from 'fp-ts/lib/Either.js';
 import * as R from 'fp-ts/lib/Record.js';
@@ -49,8 +49,9 @@ export const redirectAnyRequest: RedirectionStrategy = ([response, request]) => 
   O.fold(constant(request), ({origin, dest}) => pipe(
     request,
     Req.url(dest),
-    pipe(dest, U.sameSite(origin)) ? identity : Req.headers(
-      H.omitConfidential(request.headers)
+    pipe(dest, U.sameSite(origin)) ? identity : flow(
+      Req.headers(H.omitConfidential(request.headers)),
+      Req.credentials('omit'),
     )
   )),
 );

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -72,6 +72,10 @@ export const header = (name: string, value: string) => (request: Request) => (
   new Request(request, {headers: pipe(request.headers, H.set(name, value))})
 );
 
+export const credentials = (credentials: RequestCredentials) => (request: Request) => (
+  new Request(request, {credentials})
+);
+
 export const append = (name: string, value: string) => (request: Request) => (
   new Request(request, {headers: pipe(request.headers, H.append(name, value))})
 );


### PR DESCRIPTION
This functionality is currently missing and I need it in my project where I use session cookies. The function to set the credentials uses the built-in `RequestCredentials` type